### PR TITLE
fix: swap create-react-app default CSS with tutorial CSS

### DIFF
--- a/resources/App.css
+++ b/resources/App.css
@@ -2,6 +2,13 @@
   text-align: center;
 }
 
+html, body {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  background-image: linear-gradient(175deg, #2b3658 0%, #523e5b 100%);
+}
+
 .App-logo {
   height: 80px;
 }
@@ -17,14 +24,15 @@
   font-size: large;
 }
 
-.Item-list {
+ul {
   list-style: none;
 }
 
-.Item-list li {
-  border: 1px dotted gray;
+li {
+  padding: 10px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 400;
   width: 20%;
-  height: 3em;  
-  margin: auto;
   text-align: left;
 }


### PR DESCRIPTION
In following the tutorial, I noticed that the App.css in the master branch of the repo was the same as the default CSS in react-create-app and didn't match the styling in the tutorial.  Just swapping this out with the intended styling.