### PR TITLE
Fix failing lack of graphql package in client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "apollo-test-utils": "^0.1.1",
     "false": "0.0.4",
+    "graphql": "^0.9.2",
     "graphql-tools": "^0.10.0",
     "react": "^15.4.2",
     "react-apollo": "^0.13.2",


### PR DESCRIPTION
The client wouldn't run without this for me.