### PR TITLE
Fix #17 - Error: Cannot find module 'graphql'

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "nodemon": "^1.11.0"
   },
   "dependencies": {
-    "express": "^4.15.2"
+    "express": "^4.15.2",
+    "graphql": "^0.10.3"
   }
 }


### PR DESCRIPTION
Fixed the error about the missing dependency to 'graphql'.