### PR TITLE
Fix screencap mismatch due to App.css code

### DIFF
--- a/resources/App.css
+++ b/resources/App.css
@@ -1,5 +1,14 @@
+/* App.css at the start of tutorial 1 */
+
 .App {
   text-align: center;
+}
+
+html, body {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  background-image: linear-gradient(175deg, #2b3658 0%, #523e5b 100%);
 }
 
 .App-logo {
@@ -17,14 +26,15 @@
   font-size: large;
 }
 
-.Item-list {
+ul {
   list-style: none;
 }
 
-.Item-list li {
-  border: 1px dotted gray;
+li {
+  padding: 10px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 400;
   width: 20%;
-  height: 3em;  
-  margin: auto;
   text-align: left;
 }


### PR DESCRIPTION
/label docs

In Part 1 of the tutorial, there is a mismatch between the screen capture displayed to confirm the `App.css` copy went well and what a user sees. 

![image](https://user-images.githubusercontent.com/1347209/38008298-c887014a-3202-11e8-976e-c385d25542bb.png)

The problem seems to be the `App.css` file in master (what a user clones) does not match the one you actually used for the screen cap.

This PR fixes it in `master`. It appears in your branches, `t1-*` etc the start/end .css files do not match. Doesn't appear to be intentional...seems to be just an oversight. If I'm correct, pull this PR and I'll do a few others for you branches.

Signed-off-by: moxiegirl <moxieandmore@gmail.com>


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->